### PR TITLE
Release of Lift JQuery Module v2.10 for Lift 3.1 (Scala 2.12 and 2.11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Snapshot release for Lift v3.1-SNAPSHOT, 3.0.1 and 2.6.
 ## lift-jquery-module v2.10
 
 Released for Scala 2.11 and 2.12
-
+- [Issue #29](https://github.com/karma4u101/lift-jquery-module/issues/29) Release of v2.10 for Lift v3.1
 - [Issue #16](https://github.com/karma4u101/lift-jquery-module/issues/16) Improving the tests
 - [Issue #15](https://github.com/karma4u101/lift-jquery-module/issues/15) Adding JQuery v2.2.4
 - [Issue #13](https://github.com/karma4u101/lift-jquery-module/issues/13) Adding JQuery migrate v3.0.0

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Update log
 For update history see the [History log](https://github.com/karma4u101/lift-jquery-module#history-log) section
 
 **Latest Stable Releases:**
+- **2017-06-30** -- Module v2.10 artifact released for Lift 3.1 (Scala 2.11, 2.12)
 - **2016-12-14** -- Module v2.10 artifact released for Lift 3.0.1 (Scala 2.12)
 - **2016-06-31** -- Module v2.10 artifact released for Lift 2.6.2 (Scala 2.11,2.10,2.9.2,2.9.1-1,2.9.1), 3.0 (Scala 2.11)
 - **2015-08-08** -- Module v2.9 artifact released for Lift 2.6.2 (Scala 2.11,2.10,2.9.2,2.9.1-1,2.9.1), 3.0-M6 (Scala 2.11)

--- a/project/autobuildscript/build-publish-Lift31.txt
+++ b/project/autobuildscript/build-publish-Lift31.txt
@@ -1,8 +1,8 @@
 alias pub=publish-signed
 
-set version      in ThisBuild:="2.11-SNAPSHOT"
+set version      in ThisBuild:="2.10"
 
-set liftVersion  in ThisBuild:="3.1-SNAPSHOT"
+set liftVersion  in ThisBuild:="3.1.0-RC1"
 
 set scalaVersion in ThisBuild:="2.12.2"
 


### PR DESCRIPTION
Connected to #29 